### PR TITLE
修复zabpanel在开发过程中不能热更新的问题

### DIFF
--- a/src/components/tab/tabPanel.vue
+++ b/src/components/tab/tabPanel.vue
@@ -1,4 +1,5 @@
 <script type="text/jsx">
+  import Vue from 'vue'
   import {emitter} from '../../mixins/main'
   export default {
     name: 'zgTabPanel',
@@ -12,14 +13,20 @@
         required: true
       }
     },
+    data () {
+      return {
+        templateData: {
+          title: this.title,
+          slot: this.$slots.default
+        }
+      }
+    },
     created () {
       const parent = this.parent('zgTabs')
-      parent.addTab({
-        title: this.title,
-        slot: this.$slots.default
-      })
+      parent.addTab(this.templateData)
     },
     render (h) {
+      Vue.set(this.templateData, 'slot', this.$slots.default)
       return ''
     }
   }


### PR DESCRIPTION
在开发过程中，slot组件发生变更，会引起父组件render的重新执行，
利用Vue.set变更数据，使zgTabs重新渲染
已测试，未发现其他影响